### PR TITLE
Draw flipped bitmap if scaleX or scaleY is negative

### DIFF
--- a/src/modules/graphics/gc.c
+++ b/src/modules/graphics/gc.c
@@ -582,25 +582,28 @@ void gc_measure_text(gc_handle_t *handle, const char *text, uint16_t *w,
   *h = _h * handle->font_scale_y;
 }
 
-static void gc_draw_bitmap_helper(gc_handle_t *handle, int16_t x, int16_t y, int16_t w, int16_t h, 
-                                  int16_t xx, int16_t yy, int8_t scale_x, int8_t scale_y, uint16_t color) {
-  if (abs(scale_x) == 1 && abs(scale_y) == 1) {
-    int16_t px = x + (scale_x > 0 ? xx : w - xx);
-    int16_t py = y + (scale_y > 0 ? yy : w - yy);
+static void gc_draw_bitmap_helper(gc_handle_t *handle, int16_t x, int16_t y,
+                                  int16_t w, int16_t h, int16_t xx, int16_t yy,
+                                  int8_t scale_x, int8_t scale_y, bool flip_x,
+                                  bool flip_y, uint16_t color) {
+  if (scale_x == 1 && scale_y == 1) {
+    int16_t px = x + (flip_x ? w - xx : xx);
+    int16_t py = y + (flip_y ? h - yy : yy);
     handle->set_pixel_cb(handle, px, py, color);
   } else {
-    int16_t px = x + (scale_x > 0 ? xx * scale_x : (w - xx) * -scale_x);
-    int16_t py = y + (scale_y > 0 ? yy * scale_y : (h - yy) * -scale_y);
-    handle->fill_rect_cb(handle, px, py, abs(scale_x), abs(scale_y), color);
+    int16_t px = x + (flip_x ? (w - xx) * -scale_x : xx * scale_x);
+    int16_t py = y + (flip_y ? (h - yy) * -scale_y : yy * scale_y);
+    handle->fill_rect_cb(handle, px, py, scale_x, scale_y, color);
   }
 }
 
 void gc_draw_bitmap(gc_handle_t *handle, int16_t x, int16_t y, uint8_t *bitmap,
                     int16_t w, int16_t h, uint8_t bpp, uint16_t color,
                     bool transparent, uint16_t transparent_color,
-                    int8_t scale_x, int8_t scale_y) {
+                    uint8_t scale_x, uint8_t scale_y, bool flip_x,
+                    bool flip_y) {
   if ((x >= handle->width) || (y >= handle->height) ||
-      ((x + (w * abs(scale_x)) - 1) < 0) || ((y + (h * abs(scale_y)) - 1) < 0))
+      ((x + (w * scale_x) - 1) < 0) || ((y + (h * scale_y) - 1) < 0))
     return;
   if (bpp == 1) {
     uint16_t offset = 0;
@@ -614,7 +617,8 @@ void gc_draw_bitmap(gc_handle_t *handle, int16_t x, int16_t y, uint8_t *bitmap,
           bits = bitmap[offset];
         }
         if (bits & 0x80) {
-          gc_draw_bitmap_helper(handle, x, y, w, h, xx, yy, scale_x, scale_y, color);
+          gc_draw_bitmap_helper(handle, x, y, w, h, xx, yy, scale_x, scale_y,
+                                flip_x, flip_y, color);
         }
         bits <<= 1;
         bit++;
@@ -630,10 +634,12 @@ void gc_draw_bitmap(gc_handle_t *handle, int16_t x, int16_t y, uint8_t *bitmap,
         color = bitmap[idx] << 8 | bitmap[idx + 1];
         if (transparent) {
           if (color != transparent_color) {
-            gc_draw_bitmap_helper(handle, x, y, w, h, xx, yy, scale_x, scale_y, color);
+            gc_draw_bitmap_helper(handle, x, y, w, h, xx, yy, scale_x, scale_y,
+                                  flip_x, flip_y, color);
           }
         } else {
-          gc_draw_bitmap_helper(handle, x, y, w, h, xx, yy, scale_x, scale_y, color);
+          gc_draw_bitmap_helper(handle, x, y, w, h, xx, yy, scale_x, scale_y,
+                                flip_x, flip_y, color);
         }
       }
     }

--- a/src/modules/graphics/gc.c
+++ b/src/modules/graphics/gc.c
@@ -591,8 +591,8 @@ static void gc_draw_bitmap_helper(gc_handle_t *handle, int16_t x, int16_t y,
     int16_t py = y + (flip_y ? h - yy : yy);
     handle->set_pixel_cb(handle, px, py, color);
   } else {
-    int16_t px = x + (flip_x ? (w - xx) * -scale_x : xx * scale_x);
-    int16_t py = y + (flip_y ? (h - yy) * -scale_y : yy * scale_y);
+    int16_t px = x + (flip_x ? (w - xx) * scale_x : xx * scale_x);
+    int16_t py = y + (flip_y ? (h - yy) * scale_y : yy * scale_y);
     handle->fill_rect_cb(handle, px, py, scale_x, scale_y, color);
   }
 }

--- a/src/modules/graphics/gc.h
+++ b/src/modules/graphics/gc.h
@@ -147,6 +147,6 @@ void gc_measure_text(gc_handle_t *handle, const char *text, uint16_t *w,
 void gc_draw_bitmap(gc_handle_t *handle, int16_t x, int16_t y, uint8_t *bitmap,
                     int16_t w, int16_t h, uint8_t bpp, uint16_t color,
                     bool transparent, uint16_t transparent_color,
-                    int8_t scale_x, int8_t scale_y);
+                    uint8_t scale_x, uint8_t scale_y, bool flip_x, bool flip_y);
 
 #endif /* __GC_H */

--- a/src/modules/graphics/gc.h
+++ b/src/modules/graphics/gc.h
@@ -147,6 +147,6 @@ void gc_measure_text(gc_handle_t *handle, const char *text, uint16_t *w,
 void gc_draw_bitmap(gc_handle_t *handle, int16_t x, int16_t y, uint8_t *bitmap,
                     int16_t w, int16_t h, uint8_t bpp, uint16_t color,
                     bool transparent, uint16_t transparent_color,
-                    uint8_t scale_x, uint8_t scale_y);
+                    int8_t scale_x, int8_t scale_y);
 
 #endif /* __GC_H */

--- a/src/modules/graphics/graphics_magic_strings.h
+++ b/src/modules/graphics/graphics_magic_strings.h
@@ -72,4 +72,6 @@
 #define MSTR_GRAPHICS_MEASURE_TEXT "measureText"
 #define MSTR_GRAPHICS_DRAW_BITMAP "drawBitmap"
 #define MSTR_GRAPHICS_DISPLAY "display"
+#define MSTR_GRAPHICS_FLIP_X "flipX"
+#define MSTR_GRAPHICS_FLIP_Y "flipY"
 #endif /* __GRAPHICS_MAGIC_STRINGS_H */

--- a/src/modules/graphics/module_graphics.c
+++ b/src/modules/graphics/module_graphics.c
@@ -517,8 +517,8 @@ JERRYXX_FUN(gc_draw_bitmap_fn) {
   uint16_t color = bpp == 1 ? 1 : 0xffff;
   bool transparent = false;
   uint16_t transparent_color = 0;
-  uint8_t scale_x = 1;
-  uint8_t scale_y = 1;
+  int8_t scale_x = 1;
+  int8_t scale_y = 1;
 
   if (JERRYXX_HAS_ARG(2)) {
     jerry_value_t bitmap = JERRYXX_GET_ARG(2);

--- a/src/modules/graphics/module_graphics.c
+++ b/src/modules/graphics/module_graphics.c
@@ -517,8 +517,10 @@ JERRYXX_FUN(gc_draw_bitmap_fn) {
   uint16_t color = bpp == 1 ? 1 : 0xffff;
   bool transparent = false;
   uint16_t transparent_color = 0;
-  int8_t scale_x = 1;
-  int8_t scale_y = 1;
+  uint8_t scale_x = 1;
+  uint8_t scale_y = 1;
+  bool flip_x = false;
+  bool flip_y = false;
 
   if (JERRYXX_HAS_ARG(2)) {
     jerry_value_t bitmap = JERRYXX_GET_ARG(2);
@@ -546,6 +548,10 @@ JERRYXX_FUN(gc_draw_bitmap_fn) {
                                                 scale_x);
           scale_y = jerryxx_get_property_number(options, MSTR_GRAPHICS_SCALE_Y,
                                                 scale_y);
+          flip_x = jerryxx_get_property_boolean(options, MSTR_GRAPHICS_FLIP_X,
+                                                flip_x);
+          flip_y = jerryxx_get_property_boolean(options, MSTR_GRAPHICS_FLIP_Y,
+                                                flip_y);
         }
       }
 
@@ -561,7 +567,7 @@ JERRYXX_FUN(gc_draw_bitmap_fn) {
             jerry_get_typedarray_buffer(data, &byteOffset, &byteLength);
         uint8_t *buf = jerry_get_arraybuffer_pointer(buffer);
         gc_draw_bitmap(gc_handle, x, y, buf, w, h, bpp, color, transparent,
-                       transparent_color, scale_x, scale_y);
+                       transparent_color, scale_x, scale_y, flip_x, flip_y);
         jerry_release_value(buffer);
       } else if (jerry_value_is_string(data)) { /* decode base64 string */
         jerry_value_t global = jerry_get_global_object();
@@ -575,7 +581,7 @@ JERRYXX_FUN(gc_draw_bitmap_fn) {
             jerry_get_typedarray_buffer(decoded, &byteOffset, &byteLength);
         uint8_t *buf = jerry_get_arraybuffer_pointer(buffer);
         gc_draw_bitmap(gc_handle, x, y, buf, w, h, bpp, color, transparent,
-                       transparent_color, scale_x, scale_y);
+                       transparent_color, scale_x, scale_y, flip_x, flip_y);
         jerry_release_value(buffer);
         jerry_release_value(decoded);
         jerry_release_value(this_val);


### PR DESCRIPTION
I wanted to be able to pass `{ scaleX: -1 }` (and similar) to the `GraphicsContext.prototype.drawBitmap()` function so I could draw flipped bitmaps without including additional pre-flipped images.

To do this, I updated the C implementation of this function to handle negative integers for the `scaleX` and `scaleY` members of the `options` argument. The `scale_x` and `scale_y` values were changed from `uint8_t` to `int8_t` to support the negative values and the `gc_draw_bitmap` function was updated to call into a new `gc_draw_bitmap_helper` helper function for the actual pixel filling. At first I wasn't going to create a helper function but there was enough duplicated code that I felt it warranted a separate function implementation.

I was able to test this on an RP2040 board with a 1-bit screen (SSD1306 over I2C) but unfortunately I don't have any higher resolution set-ups available.

