### PR TITLE
Normalize some keystrokes

### DIFF
--- a/src/repl.c
+++ b/src/repl.c
@@ -211,15 +211,11 @@ static void handle_normal(char ch) {
       }
       km_repl_print_prompt();
       break;
-    case 0x01: /* Ctrl + A */
+    case 0x01: /* Ctrl+A */
       state.position = 0;
       set_cursor_to_position();
       break;
-    case 0x04: /* Ctrl + D */
-      cmd_reset(&state, NULL);
-      km_repl_print_prompt();
-      break;
-    case 0x05: /* Ctrl + E */
+    case 0x05: /* Ctrl+E */
       state.position = state.buffer_length;
       set_cursor_to_position();
       break;
@@ -238,6 +234,10 @@ static void handle_normal(char ch) {
           set_cursor_to_position();
         }
       }
+      break;
+    case 0x12: /* Ctrl+R */
+      cmd_reset(&state, NULL);
+      km_repl_print_prompt();
       break;
     case 0x1b: /* escape char */
       state.mode = KM_REPL_MODE_ESCAPE;
@@ -422,7 +422,7 @@ static void cmd_echo(km_repl_state_t *state, char *arg) {
 static void cmd_reset(km_repl_state_t *state, char *arg) {
   km_runtime_cleanup();
   km_runtime_init(false, false);
-  km_repl_printf("\r\nsoft reset\r\n");
+  km_repl_printf("\r\nSoft reset complete\r\n");
 }
 
 static size_t bytes_remained = 0;
@@ -577,8 +577,9 @@ static void cmd_help(km_repl_state_t *state, char *arg) {
 
   // print shortcuts
   km_repl_printf("\r\n");
-  km_repl_printf("CTRL+C\tAbort running code\r\n");
-  km_repl_printf("CTRL+D\tSoft reset\r\n");
+  km_repl_printf("Ctrl+C\tAbort running code\r\n");
+  km_repl_printf("Ctrl+D\tExit shell\r\n");
+  km_repl_printf("Ctrl+R\tSoft reset\r\n");
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Changes reset from Ctrl+D (usually for exiting a CLI program) -> Ctrl+R (for "reset"). Also, makes the output after a reset a little more clear.