### PR TITLE
Add host header to http.ClientRequest

### DIFF
--- a/src/modules/http/http.js
+++ b/src/modules/http/http.js
@@ -259,6 +259,13 @@ class ClientRequest extends OutgoingMessage {
       // Disable automatic chunked header - some http server do not accept it.
       // this.setHeader('transfer-encoding', 'chunked');
     }
+    if (
+      !this.headers.hasOwnProperty('Host') &&
+      !this.headers.hasOwnProperty('host')
+    ) {
+      // Host header is required for HTTP/1.1
+      this.setHeader('host', this.options.host)
+    }
     this._wbuf += `${this.options.method} ${this.path} HTTP/1.1\r\n`;
     for (var key in this.headers) {
       this._wbuf += `${key}: ${this.headers[key]}\r\n`;


### PR DESCRIPTION
Hi, 

I've been having issues making HTTP requests with `http.request` against a basic nodejs server. And it all came down to `Host` header not being set, which seems to be required by HTTP/1.1[1]

I can get it to work by manually sending host as a header with options but, for me at least, this feels like something the `http` module should do. I thought I'd make a small PR for it. 

But I'm having trouble testing it. I think I got it to build, it creates a `build/kaluma-rp2-pico-w-1.2.0-beta.1.uf2` for me, but when I use it my changes to `ClientRequest` doesn't seem to be in it :thinking:   

So I'm opening this as a Draft PR since it is totally untested.

I'm hoping someone has time to test or could give me some pointers on what I might be doing wrong when building? :smile: 

Please just ask if you need more information.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host