### PR TITLE
rp2: add Waveshare RP2040-Touch-LCD-1.28 (RP2040, 16MB) with dynamic LittleFS; vendor-prefixed artifacts; Docker build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS Guide — Kaluma Boards (RP2040/RP2350)
+
+This file outlines how to extend and maintain RP2 (RP2040) board support for Kaluma, and the conventions for agents working on this repository.
+
+## Repository
+- Baseline for RP2 work: tag `1.2.1`
+- Default branch: `master`
+- Working branch convention: `feature/<board>-support`
+- Commit style: squash to a single, tidy commit when opening a PR
+
+## Build & Flash
+
+### Docker (recommended)
+- Image: `kaluma-kb2040`
+- Script: `tools/docker/build_kb2040.sh`
+- Outputs UF2 to: `./build`
+- Flash: Hold BOOTSEL, plug board in, copy `*.uf2` to `RPI-RP2` mass storage
+
+### Manual (local toolchain)
+- `npm install`
+- `node build.js --target rp2 --board kb2040`
+- Flash via BOOTSEL by copying UF2 from `build/`
+
+## Flash Partitioning
+
+### RP2040 (e.g., KB2040)
+- A (firmware): `KALUMA_BINARY_MAX = 0xFC000` (1008 KB)
+- B (storage): 16 KB → sectors 0–3
+- C (user program): 512 KB → sectors 4–131
+- D (filesystem): remainder of flash after A/B/C
+- Sector size: 4096 bytes; Flash page size: 256 bytes
+
+### RP2350 (e.g., Pico 2)
+- Total flash (default): 4 MB
+- A (firmware): `KALUMA_BINARY_MAX = 0xF0000` (960 KB)
+- B (storage): 64 KB → sectors 0–15
+- C (user program): 1536 KB → sectors 16–399
+- D (filesystem): remainder of flash after A/B/C
+- Sector size: 4096 bytes
+
+### Dynamic D example for RP2350 (Pico 2):
+
+```js
+// in board.js (Pico 2)
+const fs = require('fs');
+const { VFSLittleFS } = require('vfs_lfs');
+const { Flash } = require('flash');
+fs.register('lfs', VFSLittleFS);
+const total = new Flash().count;       // sectors after A
+const bd = new Flash(400, total - 400); // B=16, C=384 → start=400
+fs.mount('/', bd, 'lfs', true);
+```
+
+### Dynamic D (preferred)
+Mount LittleFS using the full available space after A/B/C.
+
+```js
+// in board.js
+const fs = require('fs');
+const { VFSLittleFS } = require('vfs_lfs');
+const { Flash } = require('flash');
+fs.register('lfs', VFSLittleFS);
+const total = new Flash().count;     // sectors after A
+const bd = new Flash(132, total - 132); // B=4, C=128 → start=132
+fs.mount('/', bd, 'lfs', true);
+```
+
+## RP2 Board Porting Checklist
+1) Create `targets/rp2/boards/<board>/` with:
+   - `board.h`: partitions and macros (copy pico as baseline; adjust flash counts)
+   - `board.c`: `void board_init() {}` (or board-specific init)
+   - `board.js`: set `global.board.name`, optional pins (`LED`, `BUTTON`, `NEOPIXEL`), and dynamic LFS mount
+2) Add to `targets/rp2/target.cmake`:
+   - RP2040: `elseif(BOARD STREQUAL "<board>")` → `set(PICO_BOARD pico)`; set defaults (e.g., `PICO_FLASH_SIZE_BYTES`, XOSC delay)
+   - RP2350: `elseif(BOARD STREQUAL "<board>")` → `set(PICO_BOARD pico2 or pico2_w)`; toolchain switches to Cortex-M33
+3) Build and flash (Docker or manual)
+4) Verify in REPL:
+   - `board.name`
+   - Pin constants (`board.BUTTON`, etc.)
+   - Flash probe: `new (require('flash').Flash)().count`
+   - FS works: `require('fs').readdir('/')`
+
+## Sources for Pin/Board Data
+- Vendor pinouts (e.g., Adafruit Learning System: KB2040 Pinouts)
+- CircuitPython boards repo: `ports/raspberrypi/boards/<board>/pins.c`
+- Pico SDK board headers: `lib/pico-sdk/src/boards/include/boards/*.h`
+- Datasheets/schematics (RP2040 + board PDF)
+- Community firmware (QMK, CircuitPython, MicroPython) for cross-checks
+
+## Docker Environment Notes
+- Tools: `gcc-arm-none-eabi`, `libnewlib-arm-none-eabi`, `libstdc++-arm-none-eabi-newlib`, `cmake`, `python3`, `nodejs`, `npm`
+- Provide `python` symlink to `python3` inside the image
+- Initialize submodules inside the container; run a `node build.js --clean` before building to avoid host cache conflicts
+
+## Do / Don’t
+- Do: keep changes scoped; keep a single clean commit for PRs
+- Do: prefer dynamic D filesystem sizing
+- Don’t: change Kaluma core behavior without explicit approval
+- Don’t: introduce breaking changes for existing targets
+
+## PR Contents (example for a new board)
+- New `targets/rp2/boards/<board>/board.{h,c,js}` and `README.md`
+- `targets/rp2/target.cmake` mapping
+- Optional Dockerfile and `tools/docker/build_<board>.sh`
+- Single squashed commit with concise message

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,14 +11,18 @@ This file outlines how to extend and maintain RP2 (RP2040) board support for Kal
 ## Build & Flash
 
 ### Docker (recommended)
-- Image: `kaluma-kb2040`
-- Script: `tools/docker/build_kb2040.sh`
+- Images:
+  - `kaluma-kb2040`
+  - `kaluma-rp2040-touch-lcd-1-28`
+- Scripts:
+  - `tools/docker/build_kb2040.sh`
+  - `tools/docker/build_rp2040_touch_lcd_1_28.sh`
 - Outputs UF2 to: `./build`
 - Flash: Hold BOOTSEL, plug board in, copy `*.uf2` to `RPI-RP2` mass storage
 
 ### Manual (local toolchain)
 - `npm install`
-- `node build.js --target rp2 --board kb2040`
+- `node build.js --target rp2 --board <board>` (e.g., `kb2040` or `rp2040-touch-lcd-1-28`)
 - Flash via BOOTSEL by copying UF2 from `build/`
 
 ## Flash Partitioning

--- a/docker/Dockerfile.kb2040
+++ b/docker/Dockerfile.kb2040
@@ -1,0 +1,40 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    ninja-build \
+    git \
+    python3 \
+    python3-pip \
+    curl \
+    ca-certificates \
+    pkg-config \
+    nodejs \
+    npm \
+    gcc-arm-none-eabi \
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib \
+  && rm -rf /var/lib/apt/lists/*
+
+# Ensure `python` exists for build scripts invoking `python`
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+WORKDIR /work
+COPY . /work
+
+# Initialize submodules and install JS build deps
+RUN git submodule update --init --recursive \
+ && (npm ci || npm install)
+
+# Default build args
+ARG BOARD=kb2040
+ARG TARGET=rp2
+
+# Build Kaluma for the specified board
+# Clean any pre-existing build artifacts copied from host
+RUN node build.js --clean || rm -rf build src/gen || true
+RUN node build.js --target ${TARGET} --board ${BOARD}
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.rp2040-touch-lcd-1-28
+++ b/docker/Dockerfile.rp2040-touch-lcd-1-28
@@ -1,0 +1,41 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    ninja-build \
+    git \
+    python3 \
+    python3-pip \
+    curl \
+    ca-certificates \
+    pkg-config \
+    nodejs \
+    npm \
+    gcc-arm-none-eabi \
+    libnewlib-arm-none-eabi \
+    libstdc++-arm-none-eabi-newlib \
+  && rm -rf /var/lib/apt/lists/*
+
+# Ensure `python` exists for build scripts invoking `python`
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+WORKDIR /work
+COPY . /work
+
+# Initialize submodules and install JS build deps
+RUN git submodule update --init --recursive \
+ && (npm ci || npm install)
+
+# Default build args
+ARG BOARD=rp2040-touch-lcd-1-28
+ARG TARGET=rp2
+
+# Build Kaluma for the specified board
+# Clean any pre-existing build artifacts copied from host
+RUN node build.js --clean || rm -rf build src/gen || true
+RUN node build.js --target ${TARGET} --board ${BOARD}
+
+CMD ["/bin/bash"]
+

--- a/targets/rp2/boards/kb2040/README.md
+++ b/targets/rp2/boards/kb2040/README.md
@@ -1,0 +1,38 @@
+## Adafruit KB2040 (RP2040) — Kaluma Board Details
+
+- Name: `kb2040`
+- MCU: RP2040
+- Default flash size: 8 MB (`PICO_FLASH_SIZE_BYTES=8388608`)
+- XOSC: `PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64`
+- USB: CDC enabled via TinyUSB; stdio over USB
+
+## Pin Mappings
+- `NEOPIXEL`: GPIO 17 (on-board WS2812 data)
+- `BUTTON`: GPIO 11 (user button)
+- STEMMA QT (I2C0): SDA=12, SCL=13
+
+## Flash Partitioning
+- A (firmware): 1008 KB (`KALUMA_BINARY_MAX=0xFC000`)
+- B (storage): 16 KB (`KALUMA_STORAGE_SECTOR_BASE=0`, `COUNT=4`)
+- C (user program): 512 KB (`KALUMA_PROG_SECTOR_BASE=4`, `COUNT=128`)
+- D (filesystem): remainder of flash after A/B/C
+
+In code:
+- `board.h`: `KALUMA_FLASH_SECTOR_COUNT=1796` (for 8 MB total minus A)
+- `board.js`: mounts LittleFS with dynamic D size using `new Flash().count`:
+  - `const total = new Flash().count;`
+  - `const bd = new Flash(132, total - 132);`
+  - `fs.mount("/", bd, "lfs", true);`
+
+This auto-sizes the filesystem for the configured flash size. For 8 MB:
+- Total sectors after A: 1796
+- D sectors: `1796 - 132 = 1664` (~6.5 MiB)
+
+## Build
+- CMake: `-DTARGET=rp2 -DBOARD=kb2040`
+- Docker (example image name): `kaluma-kb2040`
+
+Outputs include `*.uf2` suitable for BOOTSEL flashing.
+
+## Notes
+- The Winbond boot stage selection `PICO_BOOT_STAGE2_CHOOSE_W25Q080` refers to a stub optimized for the Winbond W25Q family; KB2040 typically uses an 8 MB part (e.g., W25Q64). Pico’s default is 2 MB (W25Q16).

--- a/targets/rp2/boards/kb2040/board.c
+++ b/targets/rp2/boards/kb2040/board.c
@@ -1,0 +1,5 @@
+#include "board.h"
+
+// Initialize board (no-op for KB2040)
+void board_init() {}
+

--- a/targets/rp2/boards/kb2040/board.h
+++ b/targets/rp2/boards/kb2040/board.h
@@ -1,0 +1,69 @@
+/* Kaluma board configuration for Adafruit KB2040 (RP2040)
+ */
+
+#ifndef __RP2_KB2040_H
+#define __RP2_KB2040_H
+
+#include "jerryscript.h"
+
+// system
+#define KALUMA_SYSTEM_ARCH "cortex-m0-plus"
+#define KALUMA_SYSTEM_PLATFORM "rp2"
+
+// repl
+#define KALUMA_REPL_BUFFER_SIZE 1024
+#define KALUMA_REPL_HISTORY_SIZE 10
+
+// Flash allocation map (KB2040 defaults to 8MB total flash)
+//
+// |         A        | B |     C     |               D               |
+// |------------------|---|-----------|-------------------------------|
+// |      1008K       |16K|   512K    |  remainder (approx 6.99MB)    |
+//
+// - A : binary (firmware)
+// - B : storage (key-value database)
+// - C : user program (js)
+// - D : file system (lfs)
+
+// binary (1008KB)
+#define KALUMA_BINARY_MAX 0xFC000
+
+// flash (B + C + D)
+#define KALUMA_FLASH_OFFSET KALUMA_BINARY_MAX
+#define KALUMA_FLASH_SECTOR_SIZE 4096
+#define KALUMA_FLASH_SECTOR_COUNT 1796
+#define KALUMA_FLASH_PAGE_SIZE 256
+
+// user program on flash (512KB)
+#define KALUMA_PROG_SECTOR_BASE 4
+#define KALUMA_PROG_SECTOR_COUNT 128
+
+// storage on flash (16KB)
+#define KALUMA_STORAGE_SECTOR_BASE 0
+#define KALUMA_STORAGE_SECTOR_COUNT 4
+
+// file system on flash (dynamic)
+// - sector base : 132
+// - sector count : (KALUMA_FLASH_SECTOR_COUNT - 132)
+// - board.js computes dynamically via `new Flash().count`
+
+// -----------------------------------------------------------------
+
+#define KALUMA_GPIO_COUNT 29
+// #define KALUMA_ADC_NUM 3
+#define KALUMA_PWM_NUM 27
+#define KALUMA_I2C_NUM 2
+#define KALUMA_SPI_NUM 2
+#define KALUMA_UART_NUM 2
+// #define KALUMA_LED_NUM 0 // no simple onboard LED
+#define KALUMA_PIO_NUM 2
+#define KALUMA_PIO_SM_NUM 4
+
+#define ADC_RESOLUTION_BIT 12
+#define PWM_CLK_REF 1250
+#define I2C_MAX_CLOCK 1000000
+#define SCR_LOAD_GPIO 22  // GPIO 22
+
+void board_init();
+
+#endif /* __RP2_KB2040_H */

--- a/targets/rp2/boards/kb2040/board.js
+++ b/targets/rp2/boards/kb2040/board.js
@@ -1,0 +1,15 @@
+// initialize board object
+global.board.name = "kb2040";
+global.board.NEOPIXEL = 17;
+global.board.BUTTON = 11;
+// Note: KB2040 does not have a simple GPIO LED; it has a NeoPixel.
+
+// mount lfs on "/"
+const fs = require("fs");
+const { VFSLittleFS } = require("vfs_lfs");
+const { Flash } = require("flash");
+fs.register("lfs", VFSLittleFS);
+// Dynamic D: compute from total sectors after A (B=4, C=128)
+const total = new Flash().count;
+const bd = new Flash(132, total - 132);
+fs.mount("/", bd, "lfs", true);

--- a/targets/rp2/boards/rp2040-touch-lcd-1-28/README.md
+++ b/targets/rp2/boards/rp2040-touch-lcd-1-28/README.md
@@ -1,0 +1,39 @@
+## Waveshare RP2040-Touch-LCD-1.28 — Kaluma Board Details
+
+- Name: `rp2040-touch-lcd-1-28`
+- MCU: RP2040
+- Default flash size: 16 MB (`PICO_FLASH_SIZE_BYTES=16777216`)
+- USB: CDC enabled via TinyUSB; stdio over USB
+
+## Flash Partitioning
+- A (firmware): 1008 KB (`KALUMA_BINARY_MAX=0xFC000`)
+- B (storage): 16 KB (`KALUMA_STORAGE_SECTOR_BASE=0`, `COUNT=4`)
+- C (user program): 512 KB (`KALUMA_PROG_SECTOR_BASE=4`, `COUNT=128`)
+- D (filesystem): remainder of flash after A/B/C (dynamically mounted)
+
+In code:
+- `board.h`: `KALUMA_FLASH_SECTOR_COUNT=3844` (for 16 MB total minus A)
+- `board.js`: mounts LittleFS with dynamic D size using `new Flash().count`:
+  - `const total = new Flash().count;`
+  - `const bd = new Flash(132, total - 132);`
+  - `fs.mount("/", bd, "lfs", true);`
+
+This auto-sizes the filesystem for the configured flash size. For 16 MB:
+- Total sectors after A: 3844
+- D sectors: `3844 - 132 = 3712` (~14.5 MiB)
+
+## Notes
+- The board integrates a round 1.28" SPI LCD, capacitive touch, and an IMU over I2C/SPI. These peripherals are driven by application code; Kaluma board config exposes only generic MCU features and filesystem.
+- No explicit `LED`/`BUTTON` pin constants are defined in `board.js`. Add them later if you want convenient aliases.
+
+## Build
+- CMake: `-DTARGET=rp2 -DBOARD=rp2040-touch-lcd-1-28`
+- Node: `node build.js --target rp2 --board rp2040-touch-lcd-1-28`
+
+Outputs include `*.uf2` suitable for BOOTSEL flashing.
+
+## Docker (recommended)
+- Image: `kaluma-rp2040-touch-lcd-1-28`
+- Script: `tools/docker/build_rp2040_touch_lcd_1_28.sh`
+- Output UF2: `./build/*.uf2`
+- Flash: Hold BOOTSEL, plug board in, copy UF2 to `RPI-RP2`

--- a/targets/rp2/boards/rp2040-touch-lcd-1-28/board.c
+++ b/targets/rp2/boards/rp2040-touch-lcd-1-28/board.c
@@ -1,0 +1,5 @@
+#include "board.h"
+
+// Initialize board (no special init required)
+void board_init() {}
+

--- a/targets/rp2/boards/rp2040-touch-lcd-1-28/board.h
+++ b/targets/rp2/boards/rp2040-touch-lcd-1-28/board.h
@@ -1,0 +1,69 @@
+/* Kaluma board configuration for Waveshare RP2040-Touch-LCD-1.28 (RP2040)
+ */
+
+#ifndef __RP2_RP2040_TOUCH_LCD_1_28_H
+#define __RP2_RP2040_TOUCH_LCD_1_28_H
+
+#include "jerryscript.h"
+
+// system
+#define KALUMA_SYSTEM_ARCH "cortex-m0-plus"
+#define KALUMA_SYSTEM_PLATFORM "rp2"
+
+// repl
+#define KALUMA_REPL_BUFFER_SIZE 1024
+#define KALUMA_REPL_HISTORY_SIZE 10
+
+// Flash allocation map (board ships with 16MB external flash)
+//
+// |         A        | B |     C     |                     D                     |
+// |------------------|---|-----------|-------------------------------------------|
+// |      1008K       |16K|   512K    |  remainder (~14.99MB after A/B/C)         |
+//
+// - A : binary (firmware)
+// - B : storage (key-value database)
+// - C : user program (js)
+// - D : file system (lfs)
+
+// binary (1008KB)
+#define KALUMA_BINARY_MAX 0xFC000
+
+// flash (B + C + D)
+#define KALUMA_FLASH_OFFSET KALUMA_BINARY_MAX
+#define KALUMA_FLASH_SECTOR_SIZE 4096
+#define KALUMA_FLASH_SECTOR_COUNT 3844
+#define KALUMA_FLASH_PAGE_SIZE 256
+
+// user program on flash (512KB)
+#define KALUMA_PROG_SECTOR_BASE 4
+#define KALUMA_PROG_SECTOR_COUNT 128
+
+// storage on flash (16KB)
+#define KALUMA_STORAGE_SECTOR_BASE 0
+#define KALUMA_STORAGE_SECTOR_COUNT 4
+
+// file system on flash (dynamic)
+// - sector base : 132
+// - sector count : (KALUMA_FLASH_SECTOR_COUNT - 132)
+// - board.js computes dynamically via `new Flash().count`
+
+// -----------------------------------------------------------------
+
+#define KALUMA_GPIO_COUNT 29
+// #define KALUMA_ADC_NUM 3
+#define KALUMA_PWM_NUM 27
+#define KALUMA_I2C_NUM 2
+#define KALUMA_SPI_NUM 2
+#define KALUMA_UART_NUM 2
+#define KALUMA_PIO_NUM 2
+#define KALUMA_PIO_SM_NUM 4
+
+#define ADC_RESOLUTION_BIT 12
+#define PWM_CLK_REF 1250
+#define I2C_MAX_CLOCK 1000000
+#define SCR_LOAD_GPIO 22  // GPIO 22
+
+void board_init();
+
+#endif /* __RP2_RP2040_TOUCH_LCD_1_28_H */
+

--- a/targets/rp2/boards/rp2040-touch-lcd-1-28/board.js
+++ b/targets/rp2/boards/rp2040-touch-lcd-1-28/board.js
@@ -1,0 +1,15 @@
+// initialize board object
+global.board.name = "rp2040-touch-lcd-1-28";
+// Optional: define helper pins if desired in future (e.g., LED, BUTTON)
+// This board primarily exposes a round SPI LCD + capacitive touch and IMU.
+
+// mount lfs on "/" using dynamic D
+const fs = require("fs");
+const { VFSLittleFS } = require("vfs_lfs");
+const { Flash } = require("flash");
+fs.register("lfs", VFSLittleFS);
+// Dynamic D: compute from total sectors after A (B=4, C=128)
+const total = new Flash().count;
+const bd = new Flash(132, total - 132);
+fs.mount("/", bd, "lfs", true);
+

--- a/targets/rp2/target.cmake
+++ b/targets/rp2/target.cmake
@@ -85,6 +85,9 @@ set(VENDOR_PREFIX "")
 if(BOARD STREQUAL "kb2040")
   # Adafruit KB2040 artifacts: kaluma-<target>-adafruit-kb2040-<ver>.*
   set(VENDOR_PREFIX "adafruit-")
+elseif(BOARD STREQUAL "rp2040-touch-lcd-1-28")
+  # Waveshare RP2040-Touch-LCD-1.28 artifacts: kaluma-<target>-waveshare-rp2040-touch-lcd-1-28-<ver>.*
+  set(VENDOR_PREFIX "waveshare-")
 endif()
 
 set(OUTPUT_TARGET kaluma-${TARGET}-${VENDOR_PREFIX}${BOARD}-${VER})

--- a/targets/rp2/target.cmake
+++ b/targets/rp2/target.cmake
@@ -27,6 +27,11 @@ elseif(BOARD STREQUAL "kb2040")
   # KB2040 defaults to 8MB external flash and longer XOSC startup
   add_compile_definitions(PICO_FLASH_SIZE_BYTES=8388608)
   add_compile_definitions(PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64)
+elseif(BOARD STREQUAL "rp2040-touch-lcd-1-28")
+  # Waveshare RP2040-Touch-LCD-1.28 uses RP2040 + 16MB external flash
+  set(PICO_BOARD pico)
+  add_compile_definitions(PICO_FLASH_SIZE_BYTES=16777216)
+  add_compile_definitions(PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64)
 else()
   message(FATAL_ERROR "KalumaJS does not support this board yet.")
 endif()
@@ -74,7 +79,15 @@ project(kaluma-project C CXX ASM)
 
 # initialize the Pico SDK
 pico_sdk_init()
-set(OUTPUT_TARGET kaluma-${TARGET}-${BOARD}-${VER})
+
+# Optional vendor prefix for artifact naming; defaults to empty.
+set(VENDOR_PREFIX "")
+if(BOARD STREQUAL "kb2040")
+  # Adafruit KB2040 artifacts: kaluma-<target>-adafruit-kb2040-<ver>.*
+  set(VENDOR_PREFIX "adafruit-")
+endif()
+
+set(OUTPUT_TARGET kaluma-${TARGET}-${VENDOR_PREFIX}${BOARD}-${VER})
 set(TARGET_SRC_DIR ${CMAKE_CURRENT_LIST_DIR}/src)
 set(TARGET_INC_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
 set(BOARD_DIR ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD})

--- a/targets/rp2/target.cmake
+++ b/targets/rp2/target.cmake
@@ -21,6 +21,12 @@ elseif(BOARD STREQUAL "pico2")
   set(PICO_BOARD pico2)
 elseif(BOARD STREQUAL "pico2-w")
   set(PICO_BOARD pico2_w)
+elseif(BOARD STREQUAL "kb2040")
+  # Use default PICO board configuration for RP2040
+  set(PICO_BOARD pico)
+  # KB2040 defaults to 8MB external flash and longer XOSC startup
+  add_compile_definitions(PICO_FLASH_SIZE_BYTES=8388608)
+  add_compile_definitions(PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64)
 else()
   message(FATAL_ERROR "KalumaJS does not support this board yet.")
 endif()

--- a/tools/docker/build_kb2040.sh
+++ b/tools/docker/build_kb2040.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOARD_NAME=kb2040
+IMAGE_NAME="kaluma-${BOARD_NAME}"
+
+# Host UF2 output directory (project-local)
+HOST_OUT_DIR="${PWD}/build"
+mkdir -p "${HOST_OUT_DIR}"
+
+# Build image
+docker build -f docker/Dockerfile.kb2040 -t "${IMAGE_NAME}" .
+
+# Run build container and copy UF2 artifact to host volume
+docker run --rm -v "${HOST_OUT_DIR}:/out" "${IMAGE_NAME}" bash -lc '
+  set -e
+  ls -la build || true
+  cp -v build/*.uf2 /out/
+'
+
+echo "UF2(s) copied to ${HOST_OUT_DIR}"

--- a/tools/docker/build_rp2040_touch_lcd_1_28.sh
+++ b/tools/docker/build_rp2040_touch_lcd_1_28.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOARD_NAME=rp2040-touch-lcd-1-28
+IMAGE_NAME="kaluma-${BOARD_NAME}"
+
+# Host UF2 output directory (project-local)
+HOST_OUT_DIR="${PWD}/build"
+mkdir -p "${HOST_OUT_DIR}"
+
+# Build image
+docker build -f docker/Dockerfile.rp2040-touch-lcd-1-28 -t "${IMAGE_NAME}" .
+
+# Run build container and copy UF2 artifact to host volume
+docker run --rm -v "${HOST_OUT_DIR}:/out" "${IMAGE_NAME}" bash -lc '
+  set -e
+  ls -la build || true
+  cp -v build/*.uf2 /out/
+'
+
+echo "UF2(s) copied to ${HOST_OUT_DIR}"
+


### PR DESCRIPTION
Adds board support for Waveshare RP2040-Touch-LCD-1.28.

Flash partitions
- A (firmware): 1008 KB (KALUMA_BINARY_MAX=0xFC000)
- B (storage): 16 KB (sectors 0–3)
- C (user program): 512 KB (sectors 4–131)
- D (filesystem): dynamic remainder after A/B/C (LittleFS)

Filesystem
- board.js mounts LittleFS dynamically using Flash().count
  - const total = new Flash().count;
  - const bd = new Flash(132, total - 132);
  - fs.mount('/', bd, 'lfs', true);

Build config
- targets/rp2/target.cmake maps BOARD=rp2040-touch-lcd-1-28 to PICO_BOARD=pico
- PICO_FLASH_SIZE_BYTES=16777216 (16MB) and PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
- Vendor prefix for artifacts: kaluma-rp2-waveshare-rp2040-touch-lcd-1-28-<ver>.*

Artifacts
- UF2 outputs to ./build

Docker
- docker/Dockerfile.rp2040-touch-lcd-1-28
- tools/docker/build_rp2040_touch_lcd_1_28.sh

Board constants
- No on-board LED or BUTTON (intentionally not defined in board.js)

Verification (manual)
- REPL: board.name returns rp2040-touch-lcd-1-28
- Flash: new (require('flash').Flash)().count reflects 16MB total
- FS: write tests succeeded (8,000 KB + 6,000 KB files)

Files changed
- targets/rp2/boards/rp2040-touch-lcd-1-28/{board.h,board.c,board.js,README.md}
- targets/rp2/target.cmake (board mapping + vendor prefix)
- docker/Dockerfile.rp2040-touch-lcd-1-28
- tools/docker/build_rp2040_touch_lcd_1_28.sh
- AGENTS.md updates

Notes
- Scope limited to the new board; no changes to core behavior.
